### PR TITLE
fix(admin): resolve the non nullable error msg on relations field

### DIFF
--- a/src/admin/utils/formValidation.ts
+++ b/src/admin/utils/formValidation.ts
@@ -10,6 +10,6 @@ export const subscriptionFormValidationSchema = yup.object({
     .required("You must select an event type"),
   recipients: yup.array().min(1, "Please select at least one recipient"),
   collectionName: yup.string().required("Please select the collection"),
-  relations: yup.array(),
+  relations: yup.array().nullable(),
   interceptors: yup.array().nullable(),
 });


### PR DESCRIPTION
Le champ des relations a populé pouvait être `null` ( est nullable ) mais un défaut dans le schéma de validation empêchait cela.
 
Le bug était décrit ici : https://github.com/LAZONEDEV/lifecycle-notifier-strapi-plugin/issues/8