### PR TITLE
fix(TASK-1004): fix loadSubsFromPluginConfig but using getStrapi inside pluginStore

### DIFF
--- a/src/server/helpers/pluginStore.ts
+++ b/src/server/helpers/pluginStore.ts
@@ -1,7 +1,9 @@
 import pluginId from "../../common/utils/pluginId";
 import { PluginStoreKeys, StrapiStore } from "../types";
+import { getStrapi } from "./getStrapi";
 
 export const getPluginStore = (key: string): StrapiStore => {
+  const strapi = getStrapi();
   return strapi.store({
     key,
     name: pluginId,


### PR DESCRIPTION
### Demo

![image](https://github.com/LAZONEDEV/lifecycle-notifier-strapi-plugin/assets/86852257/593abf88-8170-4ff4-a51d-95aecc24303a)


**Fix du test loadSubsFromPluginConfig de par  la jour du fichier pluginStore.ts en utilisant la fonction getStrapi dans cette derniere**

**Path** : `src/server/helpers/pluginStore.ts`

infos sur la couverture


https://github.com/LAZONEDEV/lifecycle-notifier-strapi-plugin/assets/86852257/2c2b8655-fbbc-437c-929c-3154ba843c83

@vladnacht 
Je voulais surtout celui de ta fonction
