### PR TITLE
chore: avoid typescript emit test files

### DIFF
--- a/src/admin/tsconfig.json
+++ b/src/admin/tsconfig.json
@@ -19,14 +19,18 @@
     "noEmit": false
   },
 
-  "include": [
-    "./",
-    "../common/**/*"
-  ],
+  "include": ["./", "../common/**/*"],
 
   "files": [
     // force include translation files
     "./translations/en.json",
-    "./translations/fr.json",
+    "./translations/fr.json"
+  ],
+
+  "exclude": [
+    "node_modules/",
+    "**/__tests__/**/*",
+    "**/testUtils/**/*",
+    "**/__test__/**/*"
   ]
 }

--- a/src/server/tsconfig.json
+++ b/src/server/tsconfig.json
@@ -16,7 +16,8 @@
   ],
 
   "exclude": [
-    "node_modules"
-  ],
-  
+    "node_modules",
+    "**/__tests__/**/*",
+    "**/__test__/**/*"
+  ]
 }


### PR DESCRIPTION
Since it is the transpiled code of typescript that is published,
it is important not to include the test files in the output.