### PR TITLE
feat: add `FROM_THE_ENTRY_RELATION` recipient type

### DIFF
--- a/example/config/plugins.ts
+++ b/example/config/plugins.ts
@@ -59,8 +59,8 @@ export default ({ env }) => {
             eventType: "afterCreate",
             recipients: [
               {
-                type: "CUSTOM",
-                value: "custom@gmail.com",
+                type: "FROM_THE_ENTRY_RELATION",
+                value: "createdBy.email",
               },
             ],
             content:

--- a/src/common/enums/index.ts
+++ b/src/common/enums/index.ts
@@ -1,14 +1,15 @@
 export enum RecipientType {
-  // recipient email address that set as 
+  // recipient email address that set as
   // environment value
   ENV = "ENV",
   // to use field on the related collection
   FROM_MODEL = "FROM_MODEL",
+  // to use field on the related collection
+  FROM_THE_ENTRY_RELATION = "FROM_THE_ENTRY_RELATION",
   // for custom value
-  CUSTOM = "CUSTOM"
+  CUSTOM = "CUSTOM",
 }
 
 export enum EventType {
-  AfterCreate = "afterCreate"
+  AfterCreate = "afterCreate",
 }
-

--- a/src/server/helpers/notify.ts
+++ b/src/server/helpers/notify.ts
@@ -13,7 +13,11 @@ export const notify = async (
   recipient: RecipientOptionType,
   entry: Record<string, any>
 ) => {
-  const mailTo = getRecipientEmail(recipient, entry);
+  const mailTo = await getRecipientEmail(
+    recipient,
+    entry,
+    subscription.collectionName
+  );
   if (mailTo) {
     const mailOptions: MailOptions = {
       to: mailTo,

--- a/src/server/utils/getRecipientEmail.ts
+++ b/src/server/utils/getRecipientEmail.ts
@@ -8,24 +8,24 @@ export const getRecipientEmail = async (
   collectionEntry: object,
   collectionName: string
 ) => {
-  if (value.type === RecipientType.FROM_THE_ENTRY_RELATION) {
-    const strapi = getStrapi();
-    const entry = await strapi.db.query(collectionName).findOne({
-      where: { id: collectionEntry["id"] },
-      populate: [value.value],
-    });
+  switch (value.type) {
+    case RecipientType.FROM_THE_ENTRY_RELATION:
+      const strapi = getStrapi();
+      const entry = await strapi.db.query(collectionName).findOne({
+        where: { id: collectionEntry["id"] },
+        populate: [value.value],
+      });
 
-    const recipientEmail = get(entry, value.value);
-    return recipientEmail;
+      const recipientEmail = get(entry, value.value);
+      return recipientEmail;
+
+    case RecipientType.CUSTOM:
+      return value.value;
+
+    case RecipientType.FROM_MODEL:
+      return collectionEntry[value.value];
+
+    default:
+      return process.env[value.value];
   }
-
-  if (value.type === RecipientType.CUSTOM) {
-    return value.value;
-  }
-
-  if (value.type === RecipientType.FROM_MODEL) {
-    return collectionEntry[value.value];
-  }
-
-  return process.env[value.value];
 };

--- a/src/server/utils/getRecipientEmail.ts
+++ b/src/server/utils/getRecipientEmail.ts
@@ -1,14 +1,31 @@
 import { RecipientType } from "../../common/enums";
 import { RecipientOptionType } from "../../common/types";
+import { getStrapi } from "../helpers/getStrapi";
+import get from "lodash/get";
 
-export const getRecipientEmail = (value: RecipientOptionType, collectionEntry: object) => {
-  if(value.type === RecipientType.CUSTOM){
-    return value.value
+export const getRecipientEmail = async (
+  value: RecipientOptionType,
+  collectionEntry: object,
+  collectionName: string
+) => {
+  if (value.type === RecipientType.FROM_THE_ENTRY_RELATION) {
+    const strapi = getStrapi();
+    const entry = await strapi.db.query(collectionName).findOne({
+      where: { id: collectionEntry["id"] },
+      populate: [value.value],
+    });
+
+    const recipientEmail = get(entry, value.value);
+    return recipientEmail;
   }
 
-  if(value.type === RecipientType.FROM_MODEL){
-    return collectionEntry[value.value]
+  if (value.type === RecipientType.CUSTOM) {
+    return value.value;
   }
 
-  return process.env[value.value]
-}
+  if (value.type === RecipientType.FROM_MODEL) {
+    return collectionEntry[value.value];
+  }
+
+  return process.env[value.value];
+};


### PR DESCRIPTION
This recipient type add the ability to send notification to
email address that is on a relation of he entry.
For example :
Suppose we have a collection named `Planet` which has a column `discorveredBy` which is a relation to the `User` table. This type of recipient will enable us, for example, to send an e-mail to the person who discovered the planet by retrieving his e-mail from the `discorveredBy` relationship.