### PR TITLE
Interceptors and recipients get fixes

### DIFF
--- a/admin/src/components/Dialogs/SubscriptionDialog/SubscriptionDialog.tsx
+++ b/admin/src/components/Dialogs/SubscriptionDialog/SubscriptionDialog.tsx
@@ -1,5 +1,4 @@
 import { Flex, Grid, Loader, Modal, Typography } from '@strapi/design-system';
-import { useAuth } from '@strapi/strapi/admin';
 import { Form, Formik } from 'formik';
 import { EventType, eventTypes } from '../../../common/config/eventType';
 import { SubscriptionEntry } from '../../../common/types';
@@ -15,6 +14,7 @@ import { RelationPicker } from '../../Inputs/RelationPicker';
 import SelectField from '../../Inputs/SelectField';
 import TextareaField from '../../Inputs/TextareaField';
 import Footer from './../SubscriptionDialog/Footer';
+import useUserAuth from '../../../hooks/auth';
 
 export interface SubscriptionDialogProps {
   onClose: () => void;
@@ -32,14 +32,14 @@ const initialValues: Partial<SubscriptionEntry> = {
 };
 
 const SubscriptionDialog = ({ onClose, editing }: SubscriptionDialogProps) => {
-  const token = useAuth('lifecycle-notifier-strapi-plugin', (state) => state.token!);
-  const { collections, loading } = useCollections(token);
+  const authToken = useUserAuth();
+  const { collections, loading } = useCollections(authToken);
 
   const onSubmit = async (values: SubscriptionEntry) => {
     if (editing) {
-      await SubscriptionService.update(editing.id, values, token);
+      await SubscriptionService.update(editing.id, values, authToken);
     } else {
-      await SubscriptionService.create(values, token);
+      await SubscriptionService.create(values, authToken);
     }
     onClose();
   };

--- a/admin/src/hooks/auth.ts
+++ b/admin/src/hooks/auth.ts
@@ -1,0 +1,9 @@
+import { useAuth } from '@strapi/strapi/admin';
+
+const useUserAuth = () => {
+  const token = useAuth('lifecycle-notifier-strapi-plugin', (state) => state.token!);
+
+  return token;
+};
+
+export default useUserAuth;

--- a/admin/src/hooks/interceptors.ts
+++ b/admin/src/hooks/interceptors.ts
@@ -1,8 +1,10 @@
 import { useEffect, useState } from 'react';
 import { InterceptorService } from '../services/Interceptor';
 import { InterceptorOptionType } from '../types';
+import useUserAuth from './auth';
 
 export const useInterceptorsOptions = () => {
+  const authToken = useUserAuth();
   const [options, setOptions] = useState<InterceptorOptionType[]>([]);
 
   const loadInterceptors = () => {
@@ -10,7 +12,7 @@ export const useInterceptorsOptions = () => {
 
     const fetchInterceptors = async () => {
       try {
-        const existingInterceptors = await InterceptorService.getInterceptors();
+        const existingInterceptors = await InterceptorService.getInterceptors(authToken);
         if (!ignore) {
           const interceptorsOptions = existingInterceptors.map((item) => ({
             name: item,

--- a/admin/src/hooks/recipients.ts
+++ b/admin/src/hooks/recipients.ts
@@ -2,8 +2,10 @@ import { useEffect, useState } from 'react';
 import { RecipientType } from '../common/enums';
 import { RecipientOptionType } from '../common/types';
 import { ConfigService } from '../services/Config';
+import useUserAuth from './auth';
 
 export const useRecipients = () => {
+  const authToken = useUserAuth();
   const [envRecipients, setEnvRecipients] = useState<RecipientOptionType[]>([]);
 
   const loadEnvRecipients = async (envRecipients: string[]) => {
@@ -18,7 +20,7 @@ export const useRecipients = () => {
   useEffect(() => {
     let ignore = false;
 
-    ConfigService.getEnvRecipients().then((result) => {
+    ConfigService.getEnvRecipients(authToken).then((result) => {
       if (!ignore && result) {
         loadEnvRecipients(result);
       }

--- a/admin/src/services/Config.ts
+++ b/admin/src/services/Config.ts
@@ -2,8 +2,11 @@ import { apiRoutes } from '../constants/apiRoutes';
 import fetchInstance from '../utils/fetchInstance';
 
 export class ConfigService {
-  static async getEnvRecipients() {
-    const result = await fetchInstance.get<string[]>(apiRoutes.pluginEnvRecipients);
+  static async getEnvRecipients(authToken: string) {
+    const result = await fetchInstance.withAuthGet<string[]>(
+      apiRoutes.pluginEnvRecipients,
+      authToken
+    );
     return result;
   }
 }

--- a/admin/src/services/Interceptor.ts
+++ b/admin/src/services/Interceptor.ts
@@ -2,8 +2,8 @@ import { apiRoutes } from '../constants/apiRoutes';
 import fetchInstance from '../utils/fetchInstance';
 
 export class InterceptorService {
-  static async getInterceptors() {
-    const result = await fetchInstance.get(apiRoutes.pluginInterceptors);
+  static async getInterceptors(authToken: string) {
+    const result = await fetchInstance.withAuthGet(apiRoutes.pluginInterceptors, authToken);
 
     return result as string[];
   }

--- a/admin/src/services/Subscription.ts
+++ b/admin/src/services/Subscription.ts
@@ -5,30 +5,26 @@ import instance from '../utils/fetchInstance';
 export class SubscriptionService {
   static baseUrl = apiRoutes.pluginSubscriptions;
   static async get(token: string) {
-    const subs = await instance.get(SubscriptionService.baseUrl, {
-      headers: { Authorization: `Bearer ${token}` },
-    });
+    const subs = await instance.withAuthGet(SubscriptionService.baseUrl, token);
     return subs.results as SubscriptionEntry[];
   }
 
   static async create(data: Omit<SubscriptionEntry, 'id'>, token: string) {
-    const result = await instance.post<SubscriptionEntry>(SubscriptionService.baseUrl, data, {
-      headers: { Authorization: `Bearer ${token}` },
-    });
+    const result = await instance.withAuthPost<SubscriptionEntry>(
+      SubscriptionService.baseUrl,
+      token,
+      data
+    );
     return result;
   }
 
   static async delete(id: string, token: string) {
-    const result = await instance.delete(`${SubscriptionService.baseUrl}/${id}`, {
-      headers: { Authorization: `Bearer ${token}` },
-    });
+    const result = await instance.withAuthDelete(`${SubscriptionService.baseUrl}/${id}`, token);
     return result.data;
   }
 
   static async update(id: string, data: Omit<SubscriptionEntry, 'id'>, token: string) {
-    const result = await instance.put(`${SubscriptionService.baseUrl}/${id}`, data, {
-      headers: { Authorization: `Bearer ${token}` },
-    });
+    const result = await instance.withAuthPut(`${SubscriptionService.baseUrl}/${id}`, token, data);
     return result.data;
   }
 }

--- a/admin/src/utils/httpClient.ts
+++ b/admin/src/utils/httpClient.ts
@@ -88,6 +88,30 @@ class HTTPClient {
 
     return this.request<T>(url, options);
   }
+
+  async withAuthGet<T = any>(url: string, token: string): Promise<T | void> {
+    return this.get<T>(url, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+  }
+
+  async withAuthPost<T = any, P = any>(url: string, token: string, data: P): Promise<T | void> {
+    return this.post<T, P>(url, data, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+  }
+
+  async withAuthDelete<T = any>(url: string, token: string): Promise<T | void> {
+    return this.delete<T>(url, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+  }
+
+  async withAuthPut<T = any, P = any>(url: string, token: string, data: P): Promise<T | void> {
+    return this.put<T, P>(url, data, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+  }
 }
 
 export default HTTPClient;


### PR DESCRIPTION
Dans cette PR :

1. Refactor du code qui passe le header d'authentification dans la requete
L'ancien code ressemblait à ceci
```
   const result = await instance.theMethod(theURL, {
      headers: { Authorization: `Bearer ${token}` },
    });
```
Et se répétait trop ce que je trouvais moins propre.
Ce que j'ai fais ?
Créé des méthodes `withAuthGet`, `withAuthPost` ... sur le http client. Ces dernières prennent directement le token en paramètre ce qui permet d'éviter la redondance de ce code :  `{headers: { Authorization: 'Bearer ${token}' },}`

2. Ajouter le token dans la récupération des intercepteurs et recipients
3. Création du hook `useUserAuth` pour éviter de la redondance de code.