### PR TITLE
fix(TASK-2856): fix duplicate config subs entry uploaded

### DIFF
--- a/example/config/plugins.ts
+++ b/example/config/plugins.ts
@@ -60,7 +60,7 @@ export default ({ env }) => {
         subscriptions: [
           {
             collectionName: "api::planet.planet",
-            eventType: "afterCreate",
+            eventType: "create",
             recipients: [
               {
                 type: "FROM_THE_ENTRY_RELATION",
@@ -76,7 +76,7 @@ export default ({ env }) => {
           },
           {
             collectionName: "api::planet.planet",
-            eventType: "afterUpdate",
+            eventType: "update",
             recipients: [
               {
                 type: "FROM_THE_ENTRY_RELATION",
@@ -92,7 +92,7 @@ export default ({ env }) => {
           },
           {
             collectionName: "api::planet.planet",
-            eventType: "afterDelete",
+            eventType: "delete",
             recipients: [
               {
                 type: "FROM_THE_ENTRY_RELATION",

--- a/lint-staged.config.mjs
+++ b/lint-staged.config.mjs
@@ -1,18 +1,13 @@
-import path from "path";
-
 export default {
   // Type check TypeScript files
-  "**/*.(ts|tsx)": () => "yarn tsc --noEmit",
+  "**/*.(ts|tsx)": () => "tsc --noEmit",
 
   // Lint then format TypeScript and JavaScript files
   "**/*.(ts|tsx|js)": (filenames) => [
-    `next lint --fix --file ${filenames
-      .map((f) => path.relative(process.cwd(), f))
-      .join(" --file ")}`,
-    `yarn prettier --write ${filenames.join(" ")}`,
+    `eslint --fix ${filenames.join(" ")}`,
+    `prettier --write ${filenames.join(" ")}`,
   ],
 
   // Format MarkDown and JSON
-  "**/*.(md|json)": (filenames) =>
-    `yarn prettier --write ${filenames.join(" ")}`,
+  "**/*.(md|json)": (filenames) => `prettier --write ${filenames.join(" ")}`,
 };

--- a/src/admin/src/index.ts
+++ b/src/admin/src/index.ts
@@ -1,7 +1,7 @@
-import { Initializer } from './components/Initializer';
-import PluginIcon from './components/PluginIcon';
-import { PLUGIN_ID } from './pluginId';
-import { getTranslation } from './utils/getTranslation';
+import { Initializer } from "./components/Initializer";
+import PluginIcon from "./components/PluginIcon";
+import { PLUGIN_ID, PLUGIN_NAME } from "./pluginId";
+import { getTranslation } from "./utils/getTranslation";
 
 export default {
   register(app: any) {
@@ -10,10 +10,10 @@ export default {
       icon: PluginIcon,
       intlLabel: {
         id: `${PLUGIN_ID}.plugin.name`,
-        defaultMessage: PLUGIN_ID,
+        defaultMessage: PLUGIN_NAME,
       },
       Component: async () => {
-        const { App } = await import('./pages/App');
+        const { App } = await import("./pages/App");
 
         return App;
       },
@@ -23,7 +23,7 @@ export default {
       id: PLUGIN_ID,
       initializer: Initializer,
       isReady: false,
-      name: PLUGIN_ID,
+      name: PLUGIN_NAME,
     });
   },
 

--- a/src/admin/src/pluginId.ts
+++ b/src/admin/src/pluginId.ts
@@ -1,1 +1,2 @@
-export const PLUGIN_ID = 'lifecycle-notifier-strapi-plugin';
+export const PLUGIN_ID = "lifecycle-notifier-strapi-plugin";
+export const PLUGIN_NAME = "Lifecycle Notifier";

--- a/src/admin/tsconfig.json
+++ b/src/admin/tsconfig.json
@@ -1,8 +1,20 @@
 {
-  "extends": "@strapi/typescript-utils/tsconfigs/admin",
-  "include": ["./src", "./custom.d.ts", "../common"],
+  "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "rootDir": "../",
-    "baseUrl": "."
-  }
+    "composite": true,
+    "declarationMap": true,
+    "declaration": true,
+    "rootDir": "..",
+    "baseUrl": ".",
+    "outDir": "./dist",
+    "emitDeclarationOnly": false
+  },
+  "include": ["./src", "../common"],
+  "exclude": [
+    "node_modules",
+    "dist",
+    "**/*.test.ts",
+    "**/*.test.tsx",
+    "**/__tests__"
+  ]
 }

--- a/src/server/src/bootstrap.ts
+++ b/src/server/src/bootstrap.ts
@@ -1,5 +1,6 @@
-import { loadExistingSubscriptions } from './services/core/loadExistingSubscriptions';
-import { updateListenedCollectionOnChangeOnSubsCollection } from './services/core/updateListenedCollectionSet';
+import { loadSubsFromPluginConfig } from "./helpers/loadSubsFromPluginConfig";
+import { loadExistingSubscriptions } from "./services/core/loadExistingSubscriptions";
+import { updateListenedCollectionOnChangeOnSubsCollection } from "./services/core/updateListenedCollectionSet";
 
 export default () => {
   strapi.documents.use(async (context, next) => {
@@ -11,6 +12,7 @@ export default () => {
   strapi.documents.use(async (_, next) => {
     const result = await next();
     await loadExistingSubscriptions();
+    loadSubsFromPluginConfig();
     return result;
   });
 };

--- a/src/server/src/helpers/checkExistingSubs.ts
+++ b/src/server/src/helpers/checkExistingSubs.ts
@@ -1,0 +1,24 @@
+import { subscriptionCollectionUid } from "../../../common/constants";
+import { SubscriptionEntry } from "../../../common/types";
+
+const checkExistingSubs = async (subs: SubscriptionEntry) => {
+  try {
+    // Check if subscription already exists
+    const alreadyExists = await strapi.db
+      .query(subscriptionCollectionUid)
+      .findOne({
+        where: {
+          collectionName: subs.collectionName,
+          subject: subs.subject,
+        },
+      });
+    if (!alreadyExists) {
+      return false;
+    }
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+export default checkExistingSubs;

--- a/src/server/src/helpers/loadSubsFromPluginConfig.ts
+++ b/src/server/src/helpers/loadSubsFromPluginConfig.ts
@@ -1,11 +1,12 @@
-import { validate } from 'jsonschema';
-import { SubscriptionEntry } from '../../../common/types';
-import pluginId from '../../../common/utils/pluginId';
-import { ConfigKeys, PluginStoreKeys } from '../types';
-import { subscriptionsSchema } from '../utils/configValidator';
-import { getPluginConfig } from './getPluginConfig';
-import { insertSubscription } from './insertSubscription';
-import { getFromStore, saveInStore } from './pluginStore';
+import { validate } from "jsonschema";
+import { SubscriptionEntry } from "../../../common/types";
+import pluginId from "../../../common/utils/pluginId";
+import { ConfigKeys, PluginStoreKeys } from "../types";
+import { subscriptionsSchema } from "../utils/configValidator";
+import checkExistingSubs from "./checkExistingSubs";
+import { getPluginConfig } from "./getPluginConfig";
+import { insertSubscription } from "./insertSubscription";
+import { getFromStore, saveInStore } from "./pluginStore";
 
 export const loadSubsFromPluginConfig = async () => {
   const subs = getPluginConfig(ConfigKeys.SUBSCRIPTIONS);
@@ -19,7 +20,6 @@ export const loadSubsFromPluginConfig = async () => {
   }
 
   const validationResult = validate(subs, subscriptionsSchema);
-
   if (validationResult.errors.length) {
     console.error(`
     The subscriptions you provided in the ${pluginId} configs fail validation, errors are below:
@@ -30,7 +30,10 @@ export const loadSubsFromPluginConfig = async () => {
 
   try {
     for (const subscription of subs as SubscriptionEntry[]) {
-      await insertSubscription(subscription);
+      const alreadyExists = await checkExistingSubs(subscription);
+      if (!alreadyExists) {
+        await insertSubscription(subscription);
+      }
     }
     await saveInStore(PluginStoreKeys.POPULATED, true);
   } catch (error) {

--- a/src/server/tsconfig.json
+++ b/src/server/tsconfig.json
@@ -2,7 +2,9 @@
   "extends": "@strapi/typescript-utils/tsconfigs/server",
   "include": ["./src", "../common"],
   "compilerOptions": {
-    "rootDir": "../",
-    "baseUrl": "."
+    "outDir": "./dist",
+    "baseUrl": ".",
+    "rootDir": "..",
+    "composite": true
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,9 +3,7 @@
     "skipLibCheck": true,
     "esModuleInterop": true,
     "resolveJsonModule": true,
-    "noEmit": false,
     "jsx": "react",
-    "outDir": "./dist",
     "baseUrl": ".",
     "declaration": true,
     "module": "esnext",
@@ -19,10 +17,7 @@
       "common/*": ["src/common/*"]
     }
   },
-  "references": [
-    { "path": "./src/admin" },
-    { "path": "./src/server" }
-  ],
-  "include": ["./src/**/*"],
-  "exclude": ["node_modules/", "dist/"]
+  "references": [{ "path": "./src/admin" }, { "path": "./src/server" }],
+  "files": [],
+  "include": []
 }


### PR DESCRIPTION
### Demo

- [x]  Corriger le souci de duplication des souscriptions chargé

![Capture d’écran du 2025-01-13 14-46-00](https://github.com/user-attachments/assets/936e3832-a4e7-4cb2-9eaa-7447eba78ff4)

- [ ]  On n'arrive pas à lancer le plugin après build du projet exemple
    
![image](https://github.com/user-attachments/assets/c3af73ab-4c0a-480d-9a48-e81d0ba02636)

- [x] Faire apparaitre le nom du plugin quand on pointe le curseur sur son icône dans le sidebar de l’admin Strapi

- [ ] Les messages d’erreur du formalaire ne s’affiche pas. J’ai fait le constat sur le champ recipient. 
    
    